### PR TITLE
Integration tests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           docker network create integration
           docker run -d --net integration --name influx influxdb:latest
-          docker run -d --net integration --name sshlogtoinflux -p 7070:7070 -e INFLUX_URL=influx -e INFLUX_DB=integration acouvreur/ssh-log-to-influx:latest
+          docker run -d --net integration --name sshlogtoinflux -p 7070:7070 -e INFLUX_URL=influx -e INFLUX_DB=integration $(docker image ls --format "{{.Repository}}:{{.Tag}}" | grep acouvreur/ssh-log-to-influx)
           echo "Failed password for username from 213.111.245.224 port 61832 ssh2" - | netcat 127.0.0.1 7070
           sleep 1s
           [ $(docker inspect -f '{{.State.Running}}' sshlogtoinflux) == "true" ]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -41,7 +41,8 @@ jobs:
           echo "Starting influxdb..."
           docker run -d --net integration --name influx influxdb:latest
           echo "Starting $(docker image ls --format "{{.Repository}}:{{.Tag}}" | grep acouvreur/ssh-log-to-influx)"
-          docker run --net integration --name sshlogtoinflux -p 7070:7070 -e INFLUX_URL=influx -e INFLUX_DB=integration $(docker image ls --format "{{.Repository}}:{{.Tag}}" | grep acouvreur/ssh-log-to-influx)
+          docker run -d --net integration --name sshlogtoinflux -p 7070:7070 -e INFLUX_URL=influx -e INFLUX_DB=integration $(docker image ls --format "{{.Repository}}:{{.Tag}}" | grep acouvreur/ssh-log-to-influx)
+          sleep 1s
           echo "Failed password for username from 213.111.245.224 port 61832 ssh2" - | netcat 127.0.0.1 7070
           sleep 1s
           [ $(docker inspect -f '{{.State.Running}}' sshlogtoinflux) == "true" ]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Integration tests
         run: |
           docker network create integration
+          echo "Starting influxdb..."
           docker run -d --net integration --name influx influxdb:latest
-          docker run -d --net integration --name sshlogtoinflux -p 7070:7070 -e INFLUX_URL=influx -e INFLUX_DB=integration $(docker image ls --format "{{.Repository}}:{{.Tag}}" | grep acouvreur/ssh-log-to-influx)
+          echo "Starting $(docker image ls --format "{{.Repository}}:{{.Tag}}" | grep acouvreur/ssh-log-to-influx)"
+          docker run --net integration --name sshlogtoinflux -p 7070:7070 -e INFLUX_URL=influx -e INFLUX_DB=integration $(docker image ls --format "{{.Repository}}:{{.Tag}}" | grep acouvreur/ssh-log-to-influx)
           echo "Failed password for username from 213.111.245.224 port 61832 ssh2" - | netcat 127.0.0.1 7070
           sleep 1s
           [ $(docker inspect -f '{{.State.Running}}' sshlogtoinflux) == "true" ]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,3 +34,12 @@ jobs:
           tag_with_ref: true
           add_git_labels: true
           push: ${{ contains(github.ref, 'master') }}
+      
+      - name: Integration tests
+        run: |
+          docker network create integration
+          docker run -d --net integration --name influx influxdb:latest
+          docker run -d --net integration --name sshlogtoinflux -p 7070:7070 -e INFLUX_URL=influx -e INFLUX_DB=integration acouvreur/ssh-log-to-influx:latest
+          echo "Failed password for username from 213.111.245.224 port 61832 ssh2" - | netcat 127.0.0.1 7070
+          sleep 1s
+          [ $(docker inspect -f '{{.State.Running}}' sshlogtoinflux) == "true" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY package.json package.json
 COPY package-lock.json package-lock.json
 
-RUN npm i --only=production
+RUN npm i
 
-COPY ./src ./src
+COPY . .
 
 EXPOSE 7070
 


### PR DESCRIPTION
Integration tests using Github actions

needs to get the latest image generated to make it work on every pull request instead of using acouvreur/ssh-log-to-influx:latest